### PR TITLE
Shrink enumerations

### DIFF
--- a/src/utils/Enums.h
+++ b/src/utils/Enums.h
@@ -1,12 +1,12 @@
 #pragma once
 
-enum GameState {
+enum GameState : uint8_t {
 	SplashScreen_Init,
 	SplashScreen,
 	Title_Init,
 	Title,
-    IntroText_Init,
-    IntroText,
+	IntroText_Init,
+	IntroText,
 	Seed_Init,
 	Seed,
 	Game_Init,
@@ -17,56 +17,56 @@ enum GameState {
 	HighScore_NoFlash,
 };
 
-enum TitleScreenMode {
+enum TitleScreenMode : uint8_t {
 	Play,
 	HighScore
 };
 
-enum MapLevel {
+enum MapLevel : uint8_t {
 	BelowGround,
 	AboveGround,
 };
 
-enum Hearts {
+enum Hearts : uint8_t {
 	FilledIn,
 	Outline,
 };
 
-enum SpriteDataLayout {
+enum SpriteDataLayout : uint8_t {
 	Type,
 	Flags,
 	Speed,
 	Intelligence,
 };
 
-enum Direction { Up, Down, Left, Right, None };
+enum Direction : uint8_t { Up, Down, Left, Right, None };
 
-enum ObjectTypes {
-    Player = 0,  // Sprites
-    Spider,
-    Starman,
-    Skull,
-    Bolt,
-    Health = 5,
-    QBlock,  // Interactive Tiles
-    BQBlock,
-    MushBlock,
-    Bricks = 9,
-    AboveGroundExit,
-    UnderGroundExit,
-    Sign,
-    Fireball,
-    Coin,
-    Chest_Closed,
-    Chest_Open,
+enum ObjectTypes : uint8_t {
+	Player = 0,  // Sprites
+	Spider,
+	Starman,
+	Skull,
+	Bolt,
+	Health = 5,
+	QBlock,  // Interactive Tiles
+	BQBlock,
+	MushBlock,
+	Bricks = 9,
+	AboveGroundExit,
+	UnderGroundExit,
+	Sign,
+	Fireball,
+	Coin,
+	Chest_Closed,
+	Chest_Open,
 };
 
-enum EventType {
-    Off = 0,
-    Playing,
-    Death_Init,
-    Death,
-    Flash,
-    LevelExit,
-    StartLevel
+enum EventType : uint8_t {
+	Off = 0,
+	Playing,
+	Death_Init,
+	Death,
+	Flash,
+	LevelExit,
+	StartLevel
 };


### PR DESCRIPTION
Make enumerations use `uint8_t` for storage instead of `int`.

**Before:**
28292 bytes (98%) of program storage space
2195 bytes (85%) of dynamic memory

**After:**
27808 bytes (96%) of program storage space
2155 bytes (84%) of dynamic memory