### PR TITLE
Optimize switch statements

### DIFF
--- a/Astarok.ino
+++ b/Astarok.ino
@@ -51,9 +51,7 @@ void loop() {
         case GameState::SplashScreen_Init:
 
             splashScreen_Init();
-            splashScreen();
-            arduboy.display(false);
-            break;
+            /*-fallthrough*/
 
         case GameState::SplashScreen:
 
@@ -65,9 +63,7 @@ void loop() {
 
             tunes.playScore(Sounds::Theme);
             gameState = GameState::Title;
-            titleScreen();
-            arduboy.display(true);
-            break;
+            /*-fallthrough*/
 
         case GameState::Title:
 
@@ -78,9 +74,7 @@ void loop() {
         case GameState::IntroText_Init:
 
             introText_Init();
-            introText();
-            arduboy.display(true);
-            break;
+            /*-fallthrough*/
 
         case GameState::IntroText:
 
@@ -91,10 +85,8 @@ void loop() {
         case GameState::Seed_Init:
 
             seed_Init();
-            seed();
-            arduboy.display(true);
-            break;
-
+            /*-fallthrough*/
+            
         case GameState::Seed:
 
             seed();
@@ -105,15 +97,7 @@ void loop() {
 
             game.newGame();
             gameState = GameState::Game_Play;
-            game.cycle(gameState);
-            game.draw();
-
-            if (game.event == EventType::Death) {
-                game.drawScorePanel();
-            }
-
-            arduboy.displayWithBackground(game.mapNumber % 2 ? MapLevel::AboveGround : MapLevel::BelowGround);
-            break;
+            /*-fallthrough*/
 
         case GameState::Game_Play:
 
@@ -147,9 +131,7 @@ void loop() {
                 gameState = GameState::HighScore_NoFlash;
             }
 
-            highScores();
-            arduboy.display(true);
-            break;
+            /*-fallthrough*/
 
         case GameState::HighScore_Flash:
         case GameState::HighScore_NoFlash:

--- a/AstarokGame_Logic.cpp
+++ b/AstarokGame_Logic.cpp
@@ -358,9 +358,6 @@ void AstarokGame::cycle(GameState &gameState) {
             switch (obj.getType()) {
 
                 case ObjectTypes::Health:
-                    obj.move();
-                    break;
-
                 case ObjectTypes::Fireball:
                     obj.move();
                     break;
@@ -408,7 +405,7 @@ void AstarokGame::cycle(GameState &gameState) {
 
                     }
 
-                    if (obj.getActive()) { // May have been deativated just above (ie. a health) ..
+                    if (obj.getActive()) { // May have been deativated just above (i.e. a health) ..
 
                         if (isFalling) { // And therefore landing on top of an object
 

--- a/AstarokGame_Render.cpp
+++ b/AstarokGame_Render.cpp
@@ -246,7 +246,6 @@ void AstarokGame::drawPlayer() {
             if (this->eventCounter < 12) { // Do not display for first half of puff cycle.
                 this->player.draw();
             }
-
             break;
 
         case EventType::Death_Init:

--- a/src/entities/Sprite.cpp
+++ b/src/entities/Sprite.cpp
@@ -189,30 +189,21 @@ void Sprite::move() {
     switch (this->getType()) {
 
         case ObjectTypes::Player:
-
             if (this->vx == 0 && this->vy == 0) {
                 if (this->game->arduboy->getFrameCount(6) == 0) {
                 this->frame = (this->frame + 1) % 3;
                 }
             }
-
             break;
 
         case ObjectTypes::Health:
         case ObjectTypes::Coin:
-
             if (this->autoExpire > 0) {
-    
                 this->autoExpire--;
-    
                 if (this->autoExpire == 0) {
-
                     this->deactivate(false);
-
                 }
-
             }
-
             break;
 
         case ObjectTypes::Spider:
@@ -220,9 +211,7 @@ void Sprite::move() {
             if (this->vy == 0 && !this->isFalling() && hash(this->game->seed) % 20 == 0) {
                 this->vy = -(hash(this->game->seed) % 8);
             }
-
             break;
-        
     }
 
     // Handle player frame if stationary ..


### PR DESCRIPTION
- Use case fallthrough to reduce duplicate code.
Saves ~282 bytes.